### PR TITLE
update: support timeout config to avoid hanging too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ type SnapshotConfig struct {
     KeepHtml bool
     // HtmlPath where to keep the generated html, default same to image path
     HtmlPath string
+	// Timeout  the timeout config
+	Timeout time.Duration
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ type SnapshotConfig struct {
     // HtmlPath where to keep the generated html, default same to image path
     HtmlPath string
 	// Timeout  the timeout config
-	Timeout time.Duration
+    Timeout time.Duration
 }
 ```
 

--- a/render/chromedp.go
+++ b/render/chromedp.go
@@ -39,7 +39,12 @@ type SnapshotConfig struct {
 	HtmlPath string
 }
 
+// Deprecated: use MakeChartSnapshotWithContent instead
 func MakeChartSnapshot(content []byte, image string) error {
+	return MakeChartSnapshotWithContent(content, image, context.Background())
+}
+
+func MakeChartSnapshotWithContent(content []byte, image string, ctx context.Context) error {
 	path, file := filepath.Split(image)
 	suffix := filepath.Ext(file)[1:]
 	fileName := file[0 : len(file)-len(suffix)-1]
@@ -52,10 +57,14 @@ func MakeChartSnapshot(content []byte, image string) error {
 		Quality:       1,
 		KeepHtml:      false,
 	}
-	return MakeSnapshot(config)
+	return MakeSnapshotWithContent(config, ctx)
 }
 
 func MakeSnapshot(config *SnapshotConfig) error {
+	return MakeSnapshotWithContent(config, context.Background())
+}
+
+func MakeSnapshotWithContent(config *SnapshotConfig, ctx context.Context) error {
 	path := config.Path
 	fileName := config.FileName
 	content := config.RenderContent
@@ -76,7 +85,7 @@ func MakeSnapshot(config *SnapshotConfig) error {
 		htmlPath, _ = filepath.Abs(htmlPath)
 	}
 
-	ctx, cancel := chromedp.NewContext(context.Background())
+	ctx, cancel := chromedp.NewContext(ctx)
 	defer cancel()
 
 	htmlFullPath := filepath.Join(htmlPath, fileName+"."+HTML)

--- a/render/chromedp_test.go
+++ b/render/chromedp_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-echarts/snapshot-chromedp/asset"
 )
@@ -14,7 +15,31 @@ func TestFileCreation(t *testing.T) {
 	fileImage := fileName + ".png"
 	fileHtml := fileName + ".html"
 
-	err := MakeChartSnapshotWithContent(asset.RenderContent(), fileImage, context.Background())
+	err := MakeChartSnapshot(asset.RenderContent(), fileImage)
+	if err != nil {
+		t.Fatalf("Failed to create file: %s", err)
+	}
+
+	_, err = os.Stat(fileImage)
+	if os.IsNotExist(err) {
+		t.Fatalf("Image File was exist")
+	}
+
+	_, err = os.Stat(fileHtml)
+	if os.IsExist(err) {
+		t.Fatalf("Html File was not exist")
+	}
+}
+
+func TestFileCreationWithFullConfiguration(t *testing.T) {
+	fileName := "keepBothResources"
+	fileImage := fileName + ".jpeg"
+	fileHtml := fileName + ".html"
+
+	config := NewSnapshotConfig(asset.RenderContent(), fileImage)
+	config.KeepHtml = true
+
+	err := MakeSnapshot(config)
 	if err != nil {
 		t.Fatalf("Failed to create file: %s", err)
 	}
@@ -25,7 +50,19 @@ func TestFileCreation(t *testing.T) {
 	}
 
 	_, err = os.Stat(fileHtml)
-	if os.IsExist(err) {
+	if os.IsNotExist(err) {
 		t.Fatalf("Html File was not exist")
+	}
+}
+
+func TestFileCreationWithTimeout(t *testing.T) {
+	fileName := "timeoutResources.jpeg"
+
+	err := MakeSnapshot(NewSnapshotConfig(asset.RenderContent(), fileName, func(config *SnapshotConfig) {
+		config.Timeout = time.Nanosecond
+	}))
+
+	if err != context.DeadlineExceeded {
+		t.Fatalf("Can not cancel for creating file with timeout config: %s", fileName)
 	}
 }

--- a/render/chromedp_test.go
+++ b/render/chromedp_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"context"
 	_ "embed"
 	"os"
 	"testing"
@@ -13,7 +14,7 @@ func TestFileCreation(t *testing.T) {
 	fileImage := fileName + ".png"
 	fileHtml := fileName + ".html"
 
-	err := MakeChartSnapshot(asset.RenderContent(), fileImage)
+	err := MakeChartSnapshotWithContent(asset.RenderContent(), fileImage, context.Background())
 	if err != nil {
 		t.Fatalf("Failed to create file: %s", err)
 	}


### PR DESCRIPTION
Add the `timeout` config.

- Add the `Timeout` config.
- Add the handy config builder.
- Add tests.