### PR TITLE
fix: add sleep function to wait for html render

### DIFF
--- a/render/chromedp.go
+++ b/render/chromedp.go
@@ -124,6 +124,7 @@ func MakeSnapshot(config *SnapshotConfig) error {
 	err = chromedp.Run(ctx,
 		chromedp.Navigate(fmt.Sprintf("%s%s", FileProtocol, htmlFullPath)),
 		chromedp.WaitVisible(EchartsInstanceDom, chromedp.ByQuery),
+		chromedp.Sleep(3*time.Second),
 		chromedp.Evaluate(executeJS, &base64Data),
 	)
 	if err != nil {


### PR DESCRIPTION
I added the function ```chromedp.Sleep(3*time.Second)``` to wait for the HTML to render. I found this solution by checking the chromedp library and testing it with some charts, and everything is working correctly. I explained more in issue #17 

If there is anything I can improve, please let me know. I would like to collaborate

Thanks for your time