### PR TITLE
feat: support multi charts snapshot in one page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ type SnapshotConfig struct {
     HtmlPath string
     // Timeout  the timeout config
     Timeout time.Duration
-    // FullPage ONLY enable it when you have multi charts in the single page, better to set larger quality
-    FullPage bool
+    // MultiCharts ONLY enable it when you have multi charts in the single page, better to set larger quality
+    MultiCharts bool
 }
 ```
 
@@ -134,7 +134,7 @@ You can simply enable it for a full page snapshot by:
 ```go
 render.MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
 	        // enable the full page snapshot mode
-		config.FullPage = true
+		config.MultiCharts = true
 		// higher quality
 		config.Quality = 100
 	})

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ type SnapshotConfig struct {
     KeepHtml bool
     // HtmlPath where to keep the generated html, default same to image path
     HtmlPath string
-	// Timeout  the timeout config
-    Timeout time.Duration  
-	// FullPage ONLY enable it when you have multi charts in the single page, better to set larger quality
-	FullPage bool
+    // Timeout  the timeout config
+    Timeout time.Duration
+    // FullPage ONLY enable it when you have multi charts in the single page, better to set larger quality
+    FullPage bool
 }
 ```
 
@@ -133,7 +133,7 @@ You can simply enable it for a full page snapshot by:
 
 ```go
 render.MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
-	    // enable the full page snapshot
+	        // enable the full page snapshot mode
 		config.FullPage = true
 		// higher quality
 		config.Quality = 100

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ func main() {
 }
 ```
 
-Snapshot multi charts in one `Page` is also available now.
-Please make sure each chart animation disabled.
-You can simply enable it for multi charts snapshot by:
+Snapshot multi charts in one `Page` is also available now.  
+Please also make sure each chart animation disabled.  
+You can simply enable it by:
 
 ```go
 render.MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
-	        // enable the multi charts within page snapshot mode
+	        // current page contains multi charts
 		config.MultiCharts = true
 		// higher quality
 		config.Quality = 100

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ type SnapshotConfig struct {
     KeepHtml bool
     // HtmlPath where to keep the generated html, default same to image path
     HtmlPath string
-    // Timeout  the timeout config
-    Timeout time.Duration
+	// Timeout  the timeout config
+    Timeout time.Duration  
+	// FullPage ONLY enable it when you have multi charts in the single page, better to set larger quality
+	FullPage bool
 }
 ```
 
@@ -126,7 +128,19 @@ func main() {
 }
 ```
 
-> It only supports single charts for now, multi charts in one `Page` is WIP.
+Multi charts in one `Page` is also available now. Please make sure each chart animation disabled.
+You can simply enable it for a full page snapshot by:
+
+```go
+render.MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
+	    // enable the full page snapshot
+		config.FullPage = true
+		// higher quality
+		config.Quality = 100
+	})
+
+```
+
 
 # Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ func main() {
 ```
 
 Multi charts in one `Page` is also available now. Please make sure each chart animation disabled.
-You can simply enable it for a full page snapshot by:
+You can simply enable it for multi charts snapshot by:
 
 ```go
 render.MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
-	        // enable the full page snapshot mode
+	        // enable the multi charts within page snapshot mode
 		config.MultiCharts = true
 		// higher quality
 		config.Quality = 100

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ func main() {
 }
 ```
 
-Multi charts in one `Page` is also available now. Please make sure each chart animation disabled.
+Snapshot multi charts in one `Page` is also available now.
+Please make sure each chart animation disabled.
 You can simply enable it for multi charts snapshot by:
 
 ```go

--- a/asset/bar_content.go
+++ b/asset/bar_content.go
@@ -7,6 +7,13 @@ import (
 //go:embed bar.html
 var barHTML []byte
 
+//go:embed page.html
+var pageHTML []byte
+
 func RenderContent() []byte {
 	return barHTML
+}
+
+func RenderPageContent() []byte {
+	return pageHTML
 }

--- a/asset/page.html
+++ b/asset/page.html
@@ -48,6 +48,36 @@
     goecharts_avTEFYCNhBPf.setOption(option_avTEFYCNhBPf);
 </script>
 
+<div class="container">
+    <div class="item" id="avTEFYCNhBPfl" style="width:900px;height:500px;"></div>
+</div>
+
+<script type="text/javascript">
+    "use strict";
+    let goecharts_avTEFYCNhBPfl = echarts.init(document.getElementById('avTEFYCNhBPfl'), "white", {renderer: "canvas"});
+    let option_avTEFYCNhBPfl = {
+            "animation": false,
+            "color": ["#5470c6", "#91cc75", "#fac858", "#ee6666", "#73c0de", "#3ba272", "#fc8452", "#9a60b4", "#ea7ccc"],
+            "legend": {},
+            "series": [{
+                "name": "Category A",
+                "type": "line",
+                "data": [{"value": 177}, {"value": 131}, {"value": 148}, {"value": 124}, {"value": 237}, {"value": 140}, {"value": 293}]
+            }, {
+                "name": "Category B",
+                "type": "line",
+                "data": [{"value": 22}, {"value": 198}, {"value": 156}, {"value": 131}, {"value": 164}, {"value": 274}, {"value": 32}]
+            }],
+            "title": {"text": "basic line example", "subtext": "This is the subtitle."},
+            "toolbox": {},
+            "tooltip": {},
+            "xAxis": [{"data": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]}],
+            "yAxis": [{}]
+        }
+    ;
+    goecharts_avTEFYCNhBPfl.setOption(option_avTEFYCNhBPfl);
+</script>
+
 
 </body>
 </html>

--- a/render/chromedp.go
+++ b/render/chromedp.go
@@ -40,8 +40,8 @@ type SnapshotConfig struct {
 	HtmlPath string
 	// Timeout  the timeout config
 	Timeout time.Duration
-	// FullPage Only enable it when you have multi charts in the single page, better to set larger quality
-	FullPage bool
+	// MultiCharts Only enable it when you have multi charts in the single page, better to set larger quality
+	MultiCharts bool
 }
 
 type SnapshotConfigOption func(config *SnapshotConfig)
@@ -125,10 +125,10 @@ func MakeSnapshot(config *SnapshotConfig) error {
 	executeJS := fmt.Sprintf(CanvasJs, suffix, quality)
 	pagePath := fmt.Sprintf("%s%s", FileProtocol, htmlFullPath)
 
-	if true != config.FullPage {
-		imgContent, err = querySingleChartElm(ctx, pagePath, executeJS)
+	if true != config.MultiCharts {
+		imgContent, err = snapshotSingleChart(ctx, pagePath, executeJS)
 	} else {
-		imgContent, err = snapshotFullPage(ctx, pagePath, quality)
+		imgContent, err = snapshotMultiCharts(ctx, pagePath, quality)
 	}
 
 	if err != nil {
@@ -144,7 +144,7 @@ func MakeSnapshot(config *SnapshotConfig) error {
 	return nil
 }
 
-func querySingleChartElm(ctx context.Context, pagePath string, executeJS string) ([]byte, error) {
+func snapshotSingleChart(ctx context.Context, pagePath string, executeJS string) ([]byte, error) {
 	var base64Data string
 	var imageContent []byte
 	err := chromedp.Run(ctx,
@@ -161,7 +161,7 @@ func querySingleChartElm(ctx context.Context, pagePath string, executeJS string)
 
 }
 
-func snapshotFullPage(ctx context.Context, pagePath string, quality int) ([]byte, error) {
+func snapshotMultiCharts(ctx context.Context, pagePath string, quality int) ([]byte, error) {
 	var imageContent []byte
 	err := chromedp.Run(ctx,
 		chromedp.Navigate(pagePath),

--- a/render/chromedp_test.go
+++ b/render/chromedp_test.go
@@ -66,3 +66,29 @@ func TestFileCreationWithTimeout(t *testing.T) {
 		t.Fatalf("Can not cancel for creating file with timeout config: %s", fileName)
 	}
 }
+
+func TestPageCreation(t *testing.T) {
+	fileName := "page"
+	fileImage := fileName + ".png"
+	fileHtml := fileName + ".html"
+
+	err := MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
+		config.FullPage = true
+		config.Quality = 100
+	}))
+
+	if err != nil {
+		t.Fatalf("Failed to create file: %s", err)
+	}
+
+	_, err = os.Stat(fileImage)
+	if os.IsNotExist(err) {
+		t.Fatalf("Image File was exist")
+	}
+
+	_, err = os.Stat(fileHtml)
+	if os.IsExist(err) {
+		t.Fatalf("Html File was not exist")
+	}
+
+}

--- a/render/chromedp_test.go
+++ b/render/chromedp_test.go
@@ -73,7 +73,7 @@ func TestPageCreation(t *testing.T) {
 	fileHtml := fileName + ".html"
 
 	err := MakeSnapshot(NewSnapshotConfig(asset.RenderPageContent(), fileImage, func(config *SnapshotConfig) {
-		config.FullPage = true
+		config.MultiCharts = true
 		config.Quality = 100
 	}))
 


### PR DESCRIPTION
Snapshot the full page is different from the single chart.
In the single chart, it queries the echart element of the chart and get the base64 img directly.
But in the full page mode, it literally relies on the page to do real screenshot.